### PR TITLE
Adds error handling for safe browsing api requests

### DIFF
--- a/app/Http/Controllers/UrlInfoController.php
+++ b/app/Http/Controllers/UrlInfoController.php
@@ -3,24 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Url;
-use Illuminate\Http\Request;
 
 class UrlInfoController extends Controller
 {
-    /**
-     * Create a short url.
-     */
-    public function store(Request $request)
-    {
-        $this->validate($request, [
-            'url' => 'required|url',
-        ]);
-
-        $url = Url::shorten($request->get('url'));
-
-        return view('url.show')->with(compact('url'));
-    }
-
     /**
      * Redirect to the long url.
      *

--- a/app/Services/SafeBrowsing.php
+++ b/app/Services/SafeBrowsing.php
@@ -41,7 +41,7 @@ class SafeBrowsing
      */
     protected function checkSafeSearchApi($urls)
     {
-        $matches = Zttp::asJson()->post(
+        $response = Zttp::asJson()->post(
             $this->safeSearchUrl(),
             [
                 'threatInfo' => [
@@ -51,7 +51,13 @@ class SafeBrowsing
                     'threatEntries'    => $urls->all(),
                 ],
             ]
-        )->json();
+        );
+
+        if ($response->status() != 200 && $response->status() != 201) {
+            throw new \Exception('Error while checking safe browsing url ('. $response->body() .')');
+        }
+
+        $matches = $response->json();
 
         return $matches;
     }


### PR DESCRIPTION
When you forget to enable the API in the google dashboard controller, you can't shorten any url without any error message...